### PR TITLE
Add reading to vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,69 +10,68 @@ This is an English-Japanese lexicon for Machine Learning and Deep Learning termi
 ## DL tips and tricks
 - [日本語のチートシート](https://github.com/shervinea/cheatsheet-translation/blob/master/ja/cs-230-deep-learning-tips-and-tricks.md)
 
-| English | 日本語 |
-|:--- |:--------------------------- |
-| Adaptive learning rates | 適応学習率 |
-| Analytical gradient | 解析的勾配 |
-| Architecture | アーキテクチャ |
-| Backpropagation | 誤差逆伝播法 |
-| Batch normalization | バッチ正規化 |
-| Binary classification | 二項分類 |
-| Calculation | 計算 |
-| Chain rule | 連鎖律 |
-| Coefficients |  係数 |
-| Color shift | カラーシフト |
-| Contrast change | コントラスト（鮮やかさ）の修正 |
-| Convolution layer | 畳み込み層 |
-| Cross-entropy loss | 交差エントロピー誤差 |
-| Dampens oscillations | 振動を抑制する |
-| Data augmentation | データ拡張 |
-| Data processing | データ処理 |
-| Deep learning | 深層学習 |
-| Derivative | 微分 |
-| Dropout | Dropout (ドロップアウト) |
-| Early stopping | Early stopping (学習の早々な終了) |
-| Epoch | エポック |
-| Error | 損失 |
-| Evaluation | 評価 |
-| Finding optimal weights | 最適な重みの探索 |
-| Flip | 反転 |
-| Forward propagation | 順伝播 |
-| Fully connected layer | 全結合層 |
-| Gradient checking | 勾配チェック |
-| Gradient descent | 勾配降下法                   |
-| Gradient of the loss | 損失の勾配 |
-| Hyperparameter | ハイパーパラメータ |
-| Improvement to SGD | SGDの改良 |
-| Information loss | 情報損失 |
-| Learning algorithm | 学習アルゴリズム |
-| Learning rate | 学習率 |
-| Loss function | 損失関数 |
-| Mini-batch | ミニバッチ |
-| Momentum | Momentum（運動量）|
-| Neural network training | ニューラルネットワークの学習 |
-| Noise addition | ノイズの付加 |
-| Non-linear layer | 非線形層 |
-| Numerical gradient | 数値的勾配 |
-| Optimizing convergence | 収束の最適化 |
-| Output | 出力 |
-| Overfitting | 過学習 |
-| Parameter tuning | パラメータチューニング |
-| Parameter tuning | パラメータチューニング |
-| Parametrize | パラメータ化する |
-| Pre-trained weights | 学習済みの重み |
-| Prevent overfitting | 過学習を避けるために |
-| Random crop | ランダムな切り抜き |
-| Regularization | 正規化 |
-| Root Mean Square propagation | 二乗平均平方根のプロパゲーション |
-| Rotation | 回転 |
-| Transfer learning | 転移学習 |
-| Type | 種類 |
-| Updating weights | 重み更新 |
-| Validation loss | バリデーションの損失 |
-| Weight regularization | 重みの正規化 |
-| Weights initialization | 重みの初期化 |
-| Xavier initialization | Xavier初期化 |
+| English | 日本語 | 読み方
+|:--- |:--------------------------- |:-------------------------------
+| Adaptive learning rates | 適応学習率 |　てきおうがくしゅうりつ
+| Analytical gradient | 解析的勾配 |　かいせきてきこうばい
+| Architecture | アーキテクチャ |　アーキテクチャ
+| Backpropagation | 誤差逆伝播法 |　ごさぎゃくでんぱほう
+| Batch normalization | バッチ正規化 |　バッチせいきか
+| Binary classification | 二項分類 |　にこうぶんるい
+| Calculation | 計算 |　けいさん
+| Chain rule | 連鎖律 |　れんさりつ
+| Coefficients |  係数 |　けいすう
+| Color shift | カラーシフト |　カラーシフト
+| Contrast change | コントラスト（鮮やかさ）の修正 |コントラスト（あざやか）のしゅうせい
+| Convolution layer | 畳み込み層 |　たたみこみそう
+| Cross-entropy loss | 交差エントロピー誤差 |　こうさエントロピーごさ
+| Dampens oscillations | 振動を抑制する |　しんどうをよくせいする
+| Data augmentation | データ拡張 |データかくちょう
+| Data processing | データ処理 |データしょり
+| Deep learning | 深層学習 |　しんそうがくしゅう
+| Derivative | 微分 |　びぶん
+| Dropout | Dropout (ドロップアウト) |　ドロップアウト
+| Early stopping | Early stopping (学習の早々な終了) |　がくしゅのそうそうなしゅうりょう
+| Epoch | エポック |　エポック
+| Error | 損失 |　そんしつ
+| Evaluation | 評価 |　ひょうか
+| Finding optimal weights | 最適な重みの探索 | さいてきなおもみのたんさく
+| Flip | 反転 |　はんてん
+| Forward propagation | 順伝播 |　じゅんでんぱ
+| Fully connected layer | 全結合層 |　ぜんけつごうそう
+| Gradient checking | 勾配チェック |　こうばいチェック
+| Gradient descent | 勾配降下法 |　こうばいこうかっほう
+| Gradient of the loss | 損失の勾配 |　そんしつのこうばい
+| Hyperparameter | ハイパーパラメータ |　ハイパーパラメータ
+| Improvement to SGD | SGDの改良 |　SGDのかいりょう
+| Information loss | 情報損失 |　じょうほうそんしつ
+| Learning algorithm | 学習アルゴリズム |　がくしゅアルゴリズム
+| Learning rate | 学習率 |　がくしゅりつ
+| Loss function | 損失関数 | そんしつかんすう
+| Mini-batch | ミニバッチ | ミニバッチ
+| Momentum | Momentum（運動量）|　（うんどうりょう）
+| Neural network training | ニューラルネットワークの学習 | ニューラルネットワークのがくしゅ
+| Noise addition | ノイズの付加 |　ノイズのふか
+| Non-linear layer | 非線形層 |　ひせんかたちそう
+| Numerical gradient | 数値的勾配 |　すうちてきこうばい
+| Optimizing convergence | 収束の最適化 |　しゅうそくのさいてきか
+| Output | 出力 |　しゅつりょく
+| Overfitting | 過学習 |　かがくしゅ
+| Parameter tuning | パラメータチューニング |　パラメータチューニング
+| Parametrize | パラメータ化する |　パラメータかする
+| Pre-trained weights | 学習済みの重み |がくしゅすみのおもみ
+| Prevent overfitting | 過学習を避けるために |　かがくしゅをさけるために
+| Random crop | ランダムな切り抜き |ランダムなきりぬき
+| Regularization | 正規化 |　せいきか
+| Root Mean Square propagation | 二乗平均平方根のプロパゲーション |　にじょうへいきんへいほうこんのプロパゲーション
+| Rotation | 回転 |　かいてん
+| Transfer learning | 転移学習 |　てんいがくしゅ
+| Type | 種類 |　しゅるい
+| Updating weights | 重み更新 |　おもみこうしん
+| Validation loss | バリデーションの損失 |　バリデーションのそんしつ
+| Weight regularization | 重みの正規化 |　おもみのせいきか
+| Weights initialization | 重みの初期化 |　おもみのしょきか
+| Xavier initialization | Xavier初期化 |xavierしょきか
 
 
 ## Convolutional Neural Nets

--- a/README.md
+++ b/README.md
@@ -71,69 +71,69 @@ This is an English-Japanese lexicon for Machine Learning and Deep Learning termi
 | Validation loss | バリデーションの損失 |　バリデーションのそんしつ
 | Weight regularization | 重みの正規化 |　おもみのせいきか
 | Weights initialization | 重みの初期化 |　おもみのしょきか
-| Xavier initialization | Xavier初期化 |xavierしょきか
+| Xavier initialization | Xavier初期化 |　xavierしょきか
 
 
 ## Convolutional Neural Nets
 
-| English            | 日本語                 |
-|:-------------------|:-----------------------|
-| Activation | 活性化 |
-| Activation functions | 活性化関数 |
-| Activation map | 活性化マップ |
-| Anchor box | アンカーボックス |
-| Architecture | アーキテクチャ |
-| Average pooling | 平均プーリング |
-| Bias | バイアス |
-| Bounding box | バウンディングボックス |
-| Computational trick architectures | 計算トリックアーキテクチャ |
-| Convolution | 畳み込み |
-| Convolution layer | 畳み込み層 |
-| Convolutiona l Neural Networks | 畳み込みニューラルネットワーク |
-| Deep Learning | 深層学習 |
-| Detection | 検出 |
-| Dimensions | 次元 |
-| Discriminative model | 識別モデル |
-| Face verification/recognition | 顔認証/認識 |
-| Feature map | 特徴マップ |
-| Filter hyperparameters | フィルタハイパーパラメタ |
-| Fine tuning | ファインチューニング |
-| Flatten | 平滑化 |
-| Fully connected | 全結合 |
-| Generative Adversarial Net | 敵対的生成ネットワーク |
-| Generative model | 生成モデル |
-| Gram matrix | グラム行列 |
-| Image classification | 画像分類 |
-| Inception Network | インセプションネットワーク |
-| Intersection over Union | 和集合における共通部分の割合 (IoU) |
-| Layer | 層 |
-| Localization | 位置特定 |
-| Max pooling | 最大プーリング |
-| Model complexity | モデルの複雑さ|
-| Neural style transfer | ニューラルスタイル変換 |
-| Noise | ノイズ |
-| Non-linearity | 非線形性 |
-| Non-max suppression | 非極大抑制 |
-| Object detection | オブジェクト検出 |
-| Object recognition | 物体認識 |
-| One Shot Learning | One Shot学習 | 
-| Padding | パディング |
-| Parameter compatibility | パラメータの互換性 |
-| Pooling | プーリング |
-| R-CNN | R-CNN |
-| Receptive field | 受容野 |
-| Rectified Linear Unit | 正規化線形ユニット (ReLU) |
-| Residual Network (ResNet) | 残差ネットワーク (ResNet) |
-| Segmentation | セグメンテーション |
-| Siamese Network | シャムネットワーク |
-| Softmax | ソフトマックス |
-| Stride | ストライド |
-| Style matrix | スタイル行列 |
-| Style/content cost function | スタイル/コンテンツコスト関数 |
-| Training set | 学習セット |
-| Triplet loss | トリプレット損失 |
-| Tuning hyperparameters | ハイパーパラメータの調整 |
-| You Only Look Once (YOLO) | YOLO |
+| English            | 日本語                 | ひらがな
+|:-------------------|:-----------------------|:-----------------------
+| Activation | 活性化 | かっせいか
+| Activation functions | 活性化関数 |　かっせいかかんすう
+| Activation map | 活性化マップ |　かっせいかマップ
+| Anchor box | アンカーボックス |　アンカーボックス
+| Architecture | アーキテクチャ |　アーキテクチャ
+| Average pooling | 平均プーリング |　へいきんプーリング
+| Bias | バイアス |　バイアス
+| Bounding box | バウンディングボックス |　バウンディングボックス
+| Computational trick architectures | 計算トリックアーキテクチャ |　けいさんトリックアーキテクチャ
+| Convolution | 畳み込み |　たたみこみ
+| Convolution layer | 畳み込み層 |　たたみこみそう
+| Convolutiona l Neural Networks | 畳み込みニューラルネットワーク |　たたみこみニューラルネットワーク
+| Deep Learning | 深層学習 |　しんそうがくしゅ
+| Detection | 検出 |　けんしゅつ
+| Dimensions | 次元 |　じげん
+| Discriminative model | 識別モデル |　しきべつ
+| Face verification/recognition | 顔認証/認識 |　かおにんしょう／にんしょう
+| Feature map | 特徴マップ |　とくちょうマップ
+| Filter hyperparameters | フィルタハイパーパラメタ |　フィルタハイパーパラメタ
+| Fine tuning | ファインチューニング |　ファインチューニング
+| Flatten | 平滑化 |　へいかつか
+| Fully connected | 全結合 |　ぜんけつごう
+| Generative Adversarial Net | 敵対的生成ネットワーク |　てきたいてきせいせいネットワーク
+| Generative model | 生成モデル |　せいせいモデル
+| Gram matrix | グラム行列 |　グラムぎょうれつ
+| Image classification | 画像分類 |　がぞうぶんるい
+| Inception Network | インセプションネットワーク |　インセプションネットワーク
+| Intersection over Union | 和集合における共通部分の割合 (IoU) |　わしゅうごうにおけるきょうつうぶぶんのわりあい
+| Layer | 層 |　そう
+| Localization | 位置特定 |　いちとくてい
+| Max pooling | 最大プーリング |　さいだいプーリング
+| Model complexity | モデルの複雑さ|　モデルのふくざつさ
+| Neural style transfer | ニューラルスタイル変換 |ニューラルスタイルへんかん
+| Noise | ノイズ （雑音）|　ノイズ　（ざつおん）
+| Non-linearity | 非線形性 |　ひせんかたちせい
+| Non-max suppression | 非極大抑制 |ひきょくだいよくせい
+| Object detection | オブジェクト検出 |　オブジェクトけんしゅつ
+| Object recognition | 物体認識 |　ぶったいにんしょう
+| One Shot Learning | One Shot学習 | One Shotがくしゅう
+| Padding | パディング |　パディング
+| Parameter compatibility | パラメータの互換性 |　パラメータのごかんせい
+| Pooling | プーリング |　プーリング
+| R-CNN | R-CNN |　R-CNN
+| Receptive field | 受容野 |　じゅようの
+| Rectified Linear Unit | 正規化線形ユニット (ReLU) |　せいきかせんけいユニット
+| Residual Network (ResNet) | 残差ネットワーク (ResNet) |　ざんさネットワーク
+| Segmentation | セグメンテーション |　セグメンテーション
+| Siamese Network | シャムネットワーク |　シャムネットワーク
+| Softmax | ソフトマックス |　ソフトマックス
+| Stride | ストライド |　ストライド
+| Style matrix | スタイル行列 |　スタイルぎょうれつ
+| Style/content cost function | スタイル/コンテンツコスト関数 |スタイル/コンテンツコストかんすう
+| Training set | 学習セット |　がくしゅうセット
+| Triplet loss | トリプレット損失 |　トリプレットそんしつ
+| Tuning hyperparameters | ハイパーパラメータの調整 |ハイパーパラメータのちょうせい
+| You Only Look Once (YOLO) | YOLO |　YOLO
 
 
 ## Recurrent Neural Nets

--- a/README.md
+++ b/README.md
@@ -190,9 +190,8 @@ This is an English-Japanese lexicon for Machine Learning and Deep Learning termi
 
 ## Supervised Learning
 
-
 | English | 日本語 |　ひらがな
-|:--- |:--------------------------- |　:---------------------------
+|:--- |:--------------------------- |:---------------------------
 | Adaptive boosting | 適応的ブースティング | てきおうてきブースティング 
 | Batch gradient descent | バッチ勾配降下法 |バッチこうばいこうかほう
 | Bayes' rule | ベイズの定理 |ベイズのていり
@@ -314,76 +313,67 @@ This is an English-Japanese lexicon for Machine Learning and Deep Learning termi
 | Variance | 分散 |　ぶんさん
 | Weights | 重み |　おもみ
 
-## Unsupervised Learning
-
-| English            | 日本語                 |
-|:-------------------|:-----------------------|
-| something          | なになに                   |
-| something          | なになに                   |
-
-
 ## Probabilities and Statistics
 
-| English            | 日本語                 |
-|:-------------------|:-----------------------|
-| Axiom | 公理 |
-| Bayes' rule | ベイズの定理 |
-| Boundary | 境界 |
-| Characteristic function | 特性関数 |
-| Chebyshev's inequality | チェビシェフの不等式 |
-| Combinatorics | 組合せ |
-| Conditional Probability | 条件付き確率 |
-| Continuous | 連続 |
-| Cumulative distribution function (CDF) | 累積分布関数 |
-| Cumulative function | 累積関数 |
-| Discrete | 離散 |
-| Distribution | 分布 |
-| Event | 事象 |
-| Expected value | 期待値 |
-| Generalized expected value | 一般化した期待値 |
-| Jointly Distributed Random Variables | 同時分布の確率変数 |
-| Leibniz integral rule | ライプニッツの積分則 |
-| Marginal density | 周辺密度 |
-| Mutually exclusive events | 互いに排反な事象 |
-| Order | 順番 |
-| Partition | 分割 |
-| Permutation | 順列 |
-| Probability | 確率 |
-| Probability density function (PDF) | 確率密度関数 |
-| Probability distribution | 確率分布 |
-| Random variable | 確率変数 |
-| Result | 結果 |
-| Sample space | 標本空間 |
-| Sequence | 数列 |
-| Standard deviation | 標準偏差 |
-| Statistics | 統計 |
-| Subset | 部分集合 |
-| Type | 種類 |
-| Variance | 分散 |
-
+| English            | 日本語                 |　ひらがな
+|:-------------------|:-----------------------|:-----------------------
+| Axiom | 公理 | こうり
+| Bayes' rule | ベイズの定理 | ベイズのていり
+| Boundary | 境界 |　きょうかい
+| Characteristic function | 特性関数 |　とくせいかんすう
+| Chebyshev's inequality | チェビシェフの不等式 |　チェビシェフのふとうしき
+| Combinatorics | 組合せ |　くみあいせ
+| Conditional Probability | 条件付き確率 |　じょうけんつきかくりつ
+| Continuous | 連続 |　れんぞく
+| Cumulative distribution function (CDF) | 累積分布関数 |　るいせきぶんぷかんすう
+| Cumulative function | 累積関数 |　るいせきかんすう
+| Discrete | 離散 |　りさん
+| Distribution | 分布 |　ぶんぷ
+| Event | 事象 |　じしょう
+| Expected value | 期待値 |　きたいち
+| Generalized expected value | 一般化した期待値 |　いっぱんかしたきたいち
+| Jointly Distributed Random Variables | 同時分布の確率変数 |　どうじぶんぷのかくりつへんすう
+| Leibniz integral rule | ライプニッツの積分則 |　ライプニッツのせきぶんそく
+| Marginal density | 周辺密度 |　しゅうへんみつど
+| Mutually exclusive events | 互いに排反な事象 | たがいにはいはんなじしょう
+| Order | 順番 |　じゅんばん
+| Partition | 分割 |　ぶんかつ
+| Permutation | 順列 |　じゅんれつ
+| Probability | 確率 |　かくりつ
+| Probability density function (PDF) | 確率密度関数 |　かくりつみつどかんすう
+| Probability distribution | 確率分布 |　かくりつぶんぷ
+| Random variable | 確率変数 |　かくりつへんすう
+| Result | 結果 |　けっか
+| Sample space | 標本空間 |　ひょうほんくうかん
+| Sequence | 数列 |　すうれつ
+| Standard deviation | 標準偏差 |　ひょうじゅんへんさ
+| Statistics | 統計 |　とうけい
+| Subset | 部分集合 |　ぶぶんしゅうごう
+| Type | 種類 |　しゅるい
+| Variance | 分散 |　ぶんさん
 
 ## Algebra and Calculus
 
-| English            | 日本語                 |
-|:-------------------|:-----------------------|
-| Linear Algebra          | 線形代数                   |
-| Calculus          | 微積分                   |
-| Vector          | ベクトル                   |
-| Matrix          | 行列                    |
-| Row          | 行目                |
-| Column          | 列目                   |
-| Notation          | 表記法                   |
-| Element | 要素 |
-| Column-vector | 列ベクトル |
-| Square matrix | 正方行列 |
-| Invertible | 可逆 |
-| Diagonal | 対角成 |
-| Trace | 跡 |
-| Sum | 和 |
-| Symmetric decomposition | 対称分解 |
-| Symmetric | 対称 |
-| Antisymmetric | 反対称 |
-| Norm | ノルム |
-| Function | 関数 |
-| Vector space | ベクトル空間 |
-| Scalar | スカラー |
+| English            | 日本語                 |　ひらがな
+|:-------------------|:-----------------------|:-----------------------
+| Linear Algebra | 線形代数 |　せんけいだいすう
+| Calculus | 微積分 |　びせきぶん
+| Vector | ベクトル |　ベクトル
+| Matrix  | 行列 |　ぎょうれつ
+| Row | 行目 |　ぎょうめ
+| Column | 列目 |　れつめ
+| Notation | 表記法 |　ひょうきほう
+| Element | 要素 |　ようそ
+| Column-vector | 列ベクトル |　れつベクトル
+| Square matrix | 正方行列 |　せいほうぎょうれつ
+| Invertible | 可逆 |　かぎゃく
+| Diagonal | 対角 |　たいかく
+| Trace | 跡 |　あと
+| Sum | 和 |　わ
+| Symmetric decomposition | 対称分解 |　たいしょうぶんかい
+| Symmetric | 対称 |　たいしょう
+| Antisymmetric | 反対称 |　はんたいしょう
+| Norm | ノルム |　ノルム
+| Function | 関数 |　かんすう
+| Vector space | ベクトル空間 |　ベクトルくうかん
+| Scalar | スカラー |　スカラー

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is an English-Japanese lexicon for Machine Learning and Deep Learning termi
 ## DL tips and tricks
 - [日本語のチートシート](https://github.com/shervinea/cheatsheet-translation/blob/master/ja/cs-230-deep-learning-tips-and-tricks.md)
 
-| English | 日本語 | 読み方
+| English | 日本語 | ひらがな
 |:--- |:--------------------------- |:-------------------------------
 | Adaptive learning rates | 適応学習率 |　てきおうがくしゅうりつ
 | Analytical gradient | 解析的勾配 |　かいせきてきこうばい
@@ -191,131 +191,128 @@ This is an English-Japanese lexicon for Machine Learning and Deep Learning termi
 ## Supervised Learning
 
 
-| English | 日本語 |
-|:--- |:--------------------------- |
-| Adaptive boosting | 適応的ブースティング |
-| Batch gradient descent | バッチ勾配降下法 |
-| Bayes' rule | ベイズの定理 |
-| Bernoulli | ベルヌーイ |
-| Bernoulli distribution | ベルヌーイ分布 |
-| Bias | バイア |
-| Binary trees | 二分木 |
-| Boosting | ブースティング |
-| Boosting step | ブースティングステップ |
-| Canonical parameter | 正準パラメータ |
-| Chernoff bound | チェルノフ上界 |
-| Class | クラス |
-| Classification | 分類 |
-| Classification and Regression Trees (CART) | 分類・回帰ツリー (CART) |
-| Classifier | 分類器 |
-| Closed form solution | 閉形式の解 |
-| Coefficients | 係数 |
-| Continuous values | 連続値 |
-| Cost function | コスト関数 |
-| Cross-entropy | クロスエントロピー |
-| Decision boundary | 決定境界 |
-| Decision trees | 決定ツリー |
-| Discriminative model | 判別モデル | 
-| Distribution | 分布 |
-| Empirical error | 経験誤差 |
-| Ensemble methods | アンサンブル学習 |
-| Estimation | 推定 |
-| Exponential distributions | 般的な指数分布族 |
-| Exponential family | 指数分布族 ― 正準パラメータ |
-| Feature mapping | 特徴写像 |
-| Features | 特徴 |
-| Framework | フレームワーク |
-| Function | 関数 |
-| Gaussian | ガウス |
-| Gaussian Discriminant Analysis | ガウシアン判別分析 |
-| Gaussian kernel | ガウシアンカーネル |
-| Generalized Linear Models | 一般化線形モデル |
-| Generative Learning | 生成学習 |
-| Generative model | 生成モデル |
-| Generative model | 生成モデル |
-| Geometric | 幾何 |
-| Good performance | 的に良い性能 |
-| Gradient boosting | 勾配ブースティング |
-| Gradient descent | 勾配降下法 |
-| Highly uninterpretable | 解釈しにくい |
-| Hinge loss | ヒンジ損失 |
-| Hoeffding inequality | ヘフディング不等式 |
-| Hypothesis | 仮説 | 
-| Independent | 独立 |
-| Input | 入力 |
-| Interpretable | 解釈しやすい |
-| k-nearest neighbors (k-NN) | k近傍法 (k-NN) | 
-| Kernel | カーネル |
-| Kernel mapping | カーネル写像 |
-| Kernel trick | カーネルトリック |
-| Lagrange multipliers | ラグランジュ乗数 |
-| Lagrangian | ラグランジアン |
-| Learning Theory | 学習理論 |
-| Least Mean Squares | 最小2乗法 |
-| Least squared error | 最小2乗誤差 |
-| Likelihood | 尤度 |
-| Linear classifier | 線形分類器 |
-| Linear models | 線形モデル |
-| Linear regression | 線形回帰 |
-| Link function | リンク関数 |
-| Locally Weighted Regression | 局所重み付き回帰 |
-| Log-likelihood | 対数尤度 |
-| Logistic loss | ロジスティック損失 |
-| Logistic regression | ロジスティック回帰 |
-| Loss function | 損失関数 |
-| Matrix | 行列 |
-| Maximizing the likelihood | 尤度を最大にする |
-| Minimum distance | 最短距離 |
-| Misclassification | 誤分類 |
-| Multi-class logistic regression | 多クラス分類ロジスティック回帰  |
-| Multidimensional generalization | 高次元正則化 |
-| Naive Bayes | ナイーブベイズ |
-| Natural parameter | 自然パラメータ |
-| Non-linear separability | 非線形分離問題 |
-| Non-parametric approaches | ノン・パラメトリックな手法 |
-| Normal equations | 正規方程式 |
-| Normalization parameter | 正規化定数 |
-| Optimal margin classifier | 最適マージン分類器 |
-| Optimal parameters | 最適なパラメータ |
-| Optimization | 最適化 |
-| Optimization problem | 最適化問題 |
-| Ordinary least squares | 最小2乗回帰 |
-| Output | 出力 |
-| Parameter | パラメータ |
-| Parameter update | パラメータ更新 |
-| Poisson | ポワソン |
-| Prediction | 予測 |
-| Probability | 確率 |
-| Probability distributions of the data | データの確率分布 |
-| Probably Approximately Correct (PAC) | 確率的に近似的に正しい (PAC) |
-| Random forest | ランダムフォレスト |
-| Random variable | ランダムな変数 |
-| Randomly selected features | ランダムに選択された特徴量 |
-| Regression | 回帰  |
-| Sample mean | 標本平均 |
-| Shattering | 細分化 |
-| Sigmoid function | シグモイド関数 |
-| Softmax regression | ソフトマックス回帰 | 
-| Spam detection | スパム検知 |
-| Stochastic gradient descent | 確率的勾配降下法 |
-| Supervised Learning | 教師あり学習 |
-| Support Vector Machine (SVM) | サポートベクターマシン |
-| Text classification | テキスト分類 |
-| To maximize | 最大化する |
-| To minimize | 最小化する |
-| To predict | 予測する |
-| Training data | 学習データ |
-| Training error | 学習誤差 |
-| Tree-based methods | ツリーベース学習 |
-| Union bound | 和集合上界 |
-| Update rule | 更新ルール |
-| Upper bound theorem | 上界定理 |
-| Vapnik-Chervonenkis (VC) dimension | ヴァプニク・チェルヴォーネンキス次元 (VC) |
-| Variables | 変数 |
-| Variance | 分散 |
-| Weights | 重み |
-
-
+| English | 日本語 |　ひらがな
+|:--- |:--------------------------- |　:---------------------------
+| Adaptive boosting | 適応的ブースティング | てきおうてきブースティング 
+| Batch gradient descent | バッチ勾配降下法 |バッチこうばいこうかほう
+| Bayes' rule | ベイズの定理 |ベイズのていり
+| Bernoulli | ベルヌーイ |　ベルヌーイ
+| Bernoulli distribution | ベルヌーイ分布 |　ベルヌーイぶんぷ
+| Bias | バイア |　バイア
+| Binary trees | 二分木 |　にぶんぎ
+| Boosting | ブースティング |　ブースティング
+| Boosting step | ブースティングステップ |　ブースティングステップ
+| Canonical parameter | 正準パラメータ |　せいじゅんパラメータ
+| Chernoff bound | チェルノフ上界 |　チェルノフじょうかい
+| Class | クラス |　クラス
+| Classification | 分類 |　ぶんるい
+| Classification and Regression Trees (CART) | 分類・回帰ツリー (CART) |　ぶんるい・かいきツリー
+| Classifier | 分類器 |　ぶんるいき
+| Closed form solution | 閉形式の解 |　へいけいしきのかい
+| Coefficients | 係数 |　けいすう
+| Continuous values | 連続値 |　れんぞくち
+| Cost function | コスト関数 |　かんすう
+| Cross-entropy | クロスエントロピー |　クロスエントロピー
+| Decision boundary | 決定境界 |　けっていきょうかい
+| Decision trees | 決定ツリー |　てっけいツリー
+| Discriminative model | 判別モデル | はんべつモデル
+| Distribution | 分布 |　ぶんぷ
+| Empirical error | 経験誤差 |　けいけんごさ
+| Ensemble methods | アンサンブル学習 |　アンサンブルがくしゅう
+| Estimation | 推定 |　すいてい
+| Exponential distributions | 般的な指数分布族 |　てきなしすうぶんぷ
+| Exponential family | 指数分布族 ― 正準パラメータ |　しすうぶんぷ　― せいじゅんパラメータ 
+| Feature mapping | 特徴写像 |　とくちょうがぞう
+| Features | 特徴 |　とくちょう
+| Framework | フレームワーク |　フレームワーク
+| Function | 関数 |　かんすう
+| Gaussian | ガウシアン |　ガウシアン
+| Gaussian Discriminant Analysis | ガウシアン判別分析 |　ガウシアンはんべつぶんせき
+| Gaussian kernel | ガウシアンカーネル |　ガウシアンカーネル
+| Generalized Linear Models | 一般化線形モデル |　いっぱんかせんけいモデル
+| Generative Learning | 生成学習 |　せいせいがくしゅう
+| Generative model | 生成モデル |　せいせいモデル
+| Geometric | 幾何 |　きか
+| Good performance | 的に良い性能 |　てきないいせいのう
+| Gradient boosting | 勾配ブースティング |　こうばいブースティング
+| Gradient descent | 勾配降下法 |　こうばいこうかほう
+| Highly uninterpretable | 解釈しにくい |　かいしゃくしにくい
+| Hinge loss | ヒンジ損失 |ヒンジそんしつ
+| Hoeffding inequality | ヘフディング不等式 |ヘフディングふとうしき
+| Hypothesis | 仮説 | かせつ
+| Independent | 独立 |　とくりつ
+| Input | 入力 |　にゅうりょく
+| Interpretable | 解釈しやすい |　かいしゃくしやすい
+| k-nearest neighbors (k-NN) | k近傍法 (k-NN) | ｋきんぼうほう
+| Kernel | カーネル |　カーネル
+| Kernel mapping | カーネル写像 |　カーネルしゃぞう
+| Kernel trick | カーネルトリック |　カーネルトリック
+| Lagrange multipliers | ラグランジュ乗数 |　ラグランジュじょうすう
+| Lagrangian | ラグランジアン |　ラグランジアン
+| Learning Theory | 学習理論 |　がくしゅうりろん
+| Least Mean Squares | 最小2乗法 | さいしょう2じょうほう
+| Least squared error | 最小2乗誤差 | さいしょう2じょうごさ
+| Likelihood | 尤度 |　ゆうど
+| Linear classifier | 線形分類器 |　せんけいぶんるいき
+| Linear models | 線形モデル |　せんけいモデル
+| Linear regression | 線形回帰 |　せんけいかいき
+| Link function | リンク関数 |リンクかんすう
+| Locally Weighted Regression | 局所重み付き回帰 |きょくしょおもみつきかいき
+| Log-likelihood | 対数尤度 |　たいすうゆうど
+| Logistic loss | ロジスティック損失 |　ロジスティックそんしつ
+| Logistic regression | ロジスティック回帰 |　ロジスティックかいき
+| Loss function | 損失関数 |　そんしつかんすう
+| Matrix | 行列 |　ぎょうれつ
+| Maximizing the likelihood | 尤度を最大にする | ゆうどをさいだいにする
+| Minimum distance | 最短距離 |　さいたんきょり
+| Misclassification | 誤分類 |　ごぶんるい
+| Multi-class logistic regression | 多クラス分類ロジスティック回帰  |　たクラスぶんるいロジスティクスかいき
+| Multidimensional generalization | 高次元正則化 |　こうじげんせいそくか
+| Naive Bayes | ナイーブベイズ |　ナイーブベイズ
+| Natural parameter | 自然パラメータ |　しぜんパラメータ
+| Non-linear separability | 非線形分離問題 |　ひせんけいぶんりもんだい
+| Non-parametric approaches | ノン・パラメトリックな手法 |　ノン・パラメトリックなしゅほう
+| Normal equations | 正規方程式 |　せいのりかたほどしき
+| Normalization parameter | 正規化定数 |　せいきかていすう
+| Optimal margin classifier | 最適マージン分類器 |　さいてきマージンぶんるいき
+| Optimal parameters | 最適なパラメータ |　さいてきなパラメータ
+| Optimization | 最適化 |　さいてきか
+| Optimization problem | 最適化問題 |　さいてきかもんだい
+| Ordinary least squares | 最小2乗回帰 |　さいしょう2のかいき
+| Output | 出力 |　しゅつりょく
+| Parameter | パラメータ |　パラメータ
+| Parameter update | パラメータ更新 |　パラメータこうしん
+| Poisson | ポワソン |　ポワソン
+| Prediction | 予測 |　よそく
+| Probability | 確率 |　かくりつ
+| Probability distributions of the data | データの確率分布 |　データのかくりつぶんぷ
+| Probably Approximately Correct (PAC) | 確率的に近似的に正しい (PAC) |かくりつてきにきんじてきにただしい
+| Random forest | ランダムフォレスト |　ランダムフォレスト
+| Random variable | ランダムな変数 |　ランダムなへんすう
+| Randomly selected features | ランダムに選択された特徴量 |　ランダムにせんたくされたとくちょうりょう
+| Regression | 回帰  |　かいき
+| Sample mean | 標本平均 |　ひょうほんへいきん
+| Shattering | 細分化 |　さいぶんか
+| Sigmoid function | シグモイド関数 |　シグモイドかんすう
+| Softmax regression | ソフトマックス回帰 | ソフトマックスかいき
+| Spam detection | スパム検知 |　スパムけんち
+| Stochastic gradient descent | 確率的勾配降下法 |　確率的こうばいこうかほう
+| Supervised Learning | 教師あり学習 |　きょうしありがくしゅう
+| Support Vector Machine (SVM) | サポートベクターマシン |　サポートベクターマシン
+| Text classification | テキスト分類 |　テキストぶんるい
+| To maximize | 最大化する |　さいだいかする
+| To minimize | 最小化する |　さいしょうかする
+| To predict | 予測する |　よそくする
+| Training data | 学習データ |　がくしゅうデータ
+| Training error | 学習誤差 |　がくしゅうごさ
+| Tree-based methods | ツリーベース学習 |　ツリーベースがくしゅう
+| Union bound | 和集合上界 |　わしゅうごうじょうかい
+| Update rule | 更新ルール |　こうしんルール
+| Upper bound theorem | 上界定理 |　じょうかいていり
+| Vapnik-Chervonenkis (VC) dimension | ヴァプニク・チェルヴォーネンキス次元 (VC) |　ヴァプニク・チェルヴォーネンキスじげん
+| Variables | 変数 |　へんすう
+| Variance | 分散 |　ぶんさん
+| Weights | 重み |　おもみ
 
 ## Unsupervised Learning
 
@@ -390,6 +387,3 @@ This is an English-Japanese lexicon for Machine Learning and Deep Learning termi
 | Function | 関数 |
 | Vector space | ベクトル空間 |
 | Scalar | スカラー |
-
-
-

--- a/README.md
+++ b/README.md
@@ -138,54 +138,53 @@ This is an English-Japanese lexicon for Machine Learning and Deep Learning termi
 
 ## Recurrent Neural Nets
 
-| English            | 日本語                 |
-|:-------------------|:-----------------------|
-| long term/ dependencies | 長期依存性関係 |
-| Vanishing gradient | 勾配喪失 |
-| Exploding gradient | 勾配爆発 |
-| Gradient clipping  | 勾配クリッピング |
-| GRU | ゲート付き回帰型ユニット |
-| LSTM | 長・短期記憶 |
-| multiplicative gradien| 掛け算の勾配 |
-| Update gate | 更新ゲート |
-| Relevance gate | 関連ゲート |
-| Forget gate | 忘却ゲート |
-| Output gate | 出力ゲート |
-| Bidirectional RNN | 双方向 RNN |
-| Deep RNN | ディープ RNN |
-| 1-hot representation | 1-hot 表現 |
-| Word Embedding | 単語埋め込み |
-| Embedding Matrix | 埋め込み行列 |
-| CBOW | CBOW |
-| target/context likelihood model | ターゲット/コンテキスト尤度モデル |
-| skip-gram | スキップグラム |
-| negative sampling | ネガティブサンプリング |
-| Notations | ノーテーション |
-| Word2vec | Word2vec |
-| GloVe | グローブ |
-| Skip-gram | スキップグラム |
-| Cosine similarity | コサイン類似度 |
-| t-SNE | t-SNE |
-| n-gram | n-gram |
-| Perplexity | パープレキシティ |
-| Beam search | ビームサーチ |
-| Length normalization | 言語長正規化 |
-| Bleu score | ブルースコア(機械翻訳比較スコア) |
-| likelihood | 可能性 |
-| binary classifiers | バイナリ分類器 |
-| Motivation and notations | 動機と表記 |
-| co-occurence matrix | 共起行列 |
-| weighting function | 重み関数 |
-| Machine translation | 機会翻訳 |
-| a language model | 言語モデル |
-| a conditional language model | 条件付き言語モデル |
-| conditional probabilities | 条件付き確率 |
-| naive greedy search | 単純な貪欲法 |
-| Length normalization | 文章の長さの正規化 |
-| softener | 緩衝パラメータ |
-| brevity penalty | 簡潔さへのペナルティ |
-| Attention model | アテンションモデル |
-| amount of attention | 注意量 |
+| English            | 日本語                 | ひらがな
+|:-------------------|:-----------------------|:-----------------------
+| long term/ dependencies | 長期依存性関係 |　ちょうきいぞんせいかんけい
+| Vanishing gradient | 勾配喪失 |　こうばいそうしつ
+| Exploding gradient | 勾配爆発 |　こうばいばくはつ
+| Gradient clipping  | 勾配クリッピング |　こうばいクリッピング
+| GRU | ゲート付き回帰型ユニット |　ゲートつきかいきがた
+| LSTM | 長・短期記憶 |　なが‐たんききおく
+| multiplicative gradien| 掛け算の勾配 |　かけざんのこうばい
+| Update gate | 更新ゲート |　こうしんゲート
+| Relevance gate | 関連ゲート |　かんれんゲット
+| Forget gate | 忘却ゲート |　ぼうきゃくゲット
+| Output gate | 出力ゲート |　しゅつりょくゲット
+| Bidirectional RNN | 双方向 RNN |　そうほうこう　RNN
+| Deep RNN | ディープ RNN |　ディープ RNN
+| 1-hot representation | 1-hot 表現 |1-hot ひょうげん
+| Word Embedding | 単語埋め込み |　たんごうめこみ
+| Embedding Matrix | 埋め込み行列 |うめこみぎょうれつ
+| CBOW | CBOW |　CBOW
+| target/context likelihood model | ターゲット/コンテキスト尤度モデル |　ターゲット/コンテキストゆうどモデル
+| skip-gram | スキップグラム |　スキップグラム
+| negative sampling | ネガティブサンプリング |　ネガティブサンプリング
+| Notations | ノーテーション |　ノーテーション
+| Word2vec | Word2vec |　Word2vec
+| GloVe | グローブ |　グローブ
+| Cosine similarity | コサイン類似度 |　コサインるいじど
+| t-SNE | t-SNE |　t-SNE
+| n-gram | n-gram |　n-gram
+| Perplexity | パープレキシティ |　パープレキシティ
+| Beam search | ビームサーチ |　ビームサーチ
+| Length normalization | 言語長正規化 |　げんごちょうせいきか
+| Bleu score | ブルースコア(機械翻訳比較スコア) |　ブルースコア　（きかいほんや（ひかく）スコア
+| likelihood | 可能性 |　かのうせい
+| binary classifiers | バイナリ分類器 |　バイナリぶんるいき
+| Motivation and notations | 動機と表記 |　どうきとひょうき
+| co-occurence matrix | 共起行列 |　きょうきぎょうれつ
+| weighting function | 重み関数 |　おもみかんすう
+| Machine translation | 機会翻訳 |　きかいほんやく
+| a language model | 言語モデル |　げんごモデル
+| a conditional language model | 条件付き言語モデル |　じょうけんつきげんごモデル
+| conditional probabilities | 条件付き確率 |　じょうけんつきかくりつ
+| naive greedy search | 単純な貪欲法 |　たんじゅんなどんよくほう
+| Length normalization | 文章の長さの正規化 |　ぶんしょうのながさのせいきか
+| softener | 緩衝パラメータ |　かんしょうパラメータ
+| brevity penalty | 簡潔さへのペナルティ |　かんけつさへのペナルティ
+| Attention model | アテンションモデル |　アテンションモデル
+| amount of attention | 注意量 |　ちゅういりょう
 
 # Machine Learning
 


### PR DESCRIPTION
## Adding Reading
Adding reading (Hiragana - ひらがな) to the vocabulary list

## Motive
1. English speaker need to be able to read the vocabulary.
2. Create vocabulary learning sheet for people willing to learn Technical Japanese.

## To continue
A Japanese Native speaker needs to review and correct the list.